### PR TITLE
Fix klocwork issues and use secure mem, string functions

### DIFF
--- a/common.h
+++ b/common.h
@@ -25,6 +25,7 @@
 #define MAX_CHANNELS	4	/* We can handle as many channels per sensor */
 #define MAX_EVENTS	2	/* We can handle as many events per channel */
 #define MAX_TRIGGERS	8	/* Check for triggers 0 to MAX_TRIGGERS-1 */
+#define MAX_AVERAGE_WINDOW_SIZE 25
 
 #define DEV_FILE_PATH		"/dev/iio:device%d"
 #define BASE_PATH		"/sys/bus/iio/devices/iio:device%d/"

--- a/compass-calibration.c
+++ b/compass-calibration.c
@@ -377,7 +377,7 @@ static int compass_collect (sensors_event_t* event, sensor_info_t* info)
     }
 
     if (cal_data->sample_count < MAGN_DS_SIZE) {
-        memcpy(cal_data->sample[cal_data->sample_count], data, sizeof(float) * 3);
+        memcpy_s(cal_data->sample[cal_data->sample_count], sizeof(cal_data->sample), data, sizeof(float) * 3);
         cal_data->sample_count++;
         cal_data->average[0] += data[0];
         cal_data->average[1] += data[1];

--- a/filtering.c
+++ b/filtering.c
@@ -305,6 +305,7 @@ void setup_noise_filtering (int s)
 			window_size = atoi(cursor);
 	}
 
+	if (window_size > MAX_AVERAGE_WINDOW_SIZE) window_size = MAX_AVERAGE_WINDOW_SIZE;
 	switch (sensor[s].filter_type) {
 
 		case FILTER_TYPE_MEDIAN:
@@ -410,5 +411,5 @@ void record_sample (int s, const sensors_event_t* event)
 
 	cell->motion_trigger = (sensor[s].selected_trigger == sensor[s].motion_trigger_name);
 
-	memcpy(&cell->data, event, sizeof(sensors_event_t));
+	memcpy_s(&cell->data, sizeof(sensors_event_t), event, sizeof(sensors_event_t));
 }


### PR DESCRIPTION
- memcpy is replaced with secure memcpy_s function
- sprintf replaced with snprintf
- Max samples average window size is set to maximum value.
- If max samples average window size set via android property
is more than predefined maximum value, maximum value will be
set as average window size.
- strcpy replaced with strncpy_s

Tracked-On: OAM-92621
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>